### PR TITLE
TRUNK-5699 Deprecate Attributable#findPossibleValues() and Attributable#getPossibleValues()

### DIFF
--- a/api/src/main/java/org/openmrs/module/household/model/HouseholdLocation.java
+++ b/api/src/main/java/org/openmrs/module/household/model/HouseholdLocation.java
@@ -387,6 +387,7 @@ public class HouseholdLocation extends BaseOpenmrsMetadata implements java.io.Se
 		return false;
 	}
 
+	@Deprecated
 	public List<HouseholdLocation> findPossibleValues(String searchText) {
 		return null;
 	}
@@ -400,6 +401,7 @@ public class HouseholdLocation extends BaseOpenmrsMetadata implements java.io.Se
 		return getName();
 	}
 
+	@Deprecated
 	public List<HouseholdLocation> getPossibleValues() {
 		// TODO Auto-generated method stub
 		return null;


### PR DESCRIPTION
## Description of what I changed
Deprecated the methods `Attributable#findPossibleValues()` and `Attributable#getPossibleValues()`


## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5699